### PR TITLE
Implemented the --show-all and --export-files options for the aditi check command

### DIFF
--- a/docs/_posts/2025-08-29-1425-improved-file-list-handling.md
+++ b/docs/_posts/2025-08-29-1425-improved-file-list-handling.md
@@ -1,0 +1,93 @@
+---
+layout: post
+title: "Improved File List Handling in aditi check Command"
+date: 2025-08-29 14:25:00 -0400
+author: Aditi Development Team
+tags: [features, ui, usability]
+summary: "New options for complete file list visibility in check command output"
+---
+
+## Better Visibility for Large-Scale DITA Migration Projects
+
+When working with large documentation repositories, the `aditi check` command helps identify DITA compatibility issues across hundreds or even thousands of AsciiDoc files. Previously, when a rule violation affected many files, the output would truncate the file list after 10 entries, showing "... and X more" to keep the terminal output manageable.
+
+While this truncation keeps the output clean, users often need to see the complete list of affected files for planning and tracking purposes. Today's update introduces two new options that give you full control over how file lists are displayed.
+
+## New Options
+
+### `--show-all` Flag
+
+The `--show-all` flag displays all affected files directly in the terminal without truncation:
+
+```bash
+aditi check --rule ContentType --show-all
+```
+
+This is particularly useful when you need to quickly see all affected files for a specific rule violation without exporting to a file.
+
+### `--export-files` Option
+
+For more permanent records or when dealing with very large file lists, the `--export-files` option saves the complete list to a file:
+
+```bash
+aditi check --export-files violations-report.txt
+```
+
+The exported file includes:
+- Generation timestamp
+- Total files processed and issues found
+- Files grouped by rule name
+- Sorted file paths for easy navigation
+
+Example export format:
+```
+# Aditi Check Results - Files with Issues
+# Generated: 2025-08-29T14:25:22.565988
+# Total files: 150
+# Total issues: 342
+
+## ContentType (45 files)
+  - modules/getting-started.adoc
+  - modules/installation-guide.adoc
+  - modules/troubleshooting.adoc
+  ...
+
+## EntityReference (23 files)
+  - assemblies/product-overview.adoc
+  - assemblies/quick-start.adoc
+  ...
+```
+
+## Using Both Options Together
+
+You can combine both options for maximum flexibility:
+
+```bash
+aditi check --show-all --export-files full-report.txt --rule BlockTitle
+```
+
+This displays all files in the terminal while also creating a permanent record.
+
+## Consistent Experience Across Commands
+
+The same file list display logic is now used in both the `check` command and the `journey` command, ensuring a consistent user experience throughout the tool.
+
+## Implementation Details
+
+The implementation adds a reusable `_display_file_list()` helper method to the processor module, which handles:
+- Truncation logic (show 10 files by default)
+- Full display when requested
+- Consistent formatting across different commands
+
+This approach maintains backward compatibility while providing the flexibility needed for large-scale documentation projects.
+
+## Next Steps
+
+These improvements make it easier to track and manage DITA migration progress across large documentation sets. Combined with the journey workflow, teams can now better plan and execute their migration strategies with full visibility into the scope of work required.
+
+Try out the new options with:
+```bash
+aditi check --help
+```
+
+Happy migrating!

--- a/src/aditi/cli.py
+++ b/src/aditi/cli.py
@@ -156,6 +156,16 @@ def check(
         help="Check only specific rule (e.g., EntityReference)",
     ),
     verbose: bool = verbose_option,
+    show_all: bool = typer.Option(
+        False,
+        "--show-all",
+        help="Show all affected files without truncation",
+    ),
+    export_files: Optional[Path] = typer.Option(
+        None,
+        "--export-files",
+        help="Export full list of affected files to specified file",
+    ),
 ) -> None:
     """Check AsciiDoc files for DITA compatibility issues.
     
@@ -163,7 +173,7 @@ def check(
     to be addressed before migration to DITA.
     """
     setup_logging(verbose)
-    check_command(paths, rule, verbose)
+    check_command(paths, rule, verbose, show_all, export_files)
 
 
 @app.command()

--- a/src/aditi/commands/check.py
+++ b/src/aditi/commands/check.py
@@ -36,6 +36,16 @@ def check_command(
         "-v",
         help="Show detailed violation information",
     ),
+    show_all: bool = typer.Option(
+        False,
+        "--show-all",
+        help="Show all affected files without truncation",
+    ),
+    export_files: Optional[Path] = typer.Option(
+        None,
+        "--export-files",
+        help="Export full list of affected files to specified file",
+    ),
 ) -> None:
     """Check AsciiDoc files for DITA compatibility issues.
     
@@ -184,10 +194,10 @@ def check_command(
             
         # Display detailed results if verbose
         if verbose:
-            _display_verbose_results(result, processor)
+            _display_verbose_results(result, processor, show_all, export_files)
         else:
-            # Display summary
-            processor.display_summary(result)
+            # Display summary with new options
+            processor.display_summary(result, show_all=show_all, export_files=export_files)
             
     except Exception as e:
         console.print(f"[red]Error during check:[/red] {e}")
@@ -198,7 +208,7 @@ def check_command(
             vale_container.cleanup()
 
 
-def _display_verbose_results(result, processor):
+def _display_verbose_results(result, processor, show_all=False, export_files=None):
     """Display verbose results with detailed violation information."""
     console.print("\n📊 Detailed Analysis Results\n")
     

--- a/src/aditi/commands/journey.py
+++ b/src/aditi/commands/journey.py
@@ -942,11 +942,16 @@ def process_single_rule(rule, issues, description, processor, config_manager) ->
     # Show affected files
     files_affected = list(set(v.file_path for v in issues))
     console.print("These files have this issue:")
-    for i, file_path in enumerate(files_affected[:10]):
-        rel_path = file_path.relative_to(Path.cwd())
-        console.print(f"  • {rel_path}")
-    if len(files_affected) > 10:
-        console.print(f"  ... and {len(files_affected) - 10} more")
+    # Use the processor's file list display helper if available
+    if hasattr(processor, '_display_file_list'):
+        processor._display_file_list(files_affected, rule.name, show_all=False, max_display=10)
+    else:
+        # Fallback to inline display
+        for i, file_path in enumerate(files_affected[:10]):
+            rel_path = file_path.relative_to(Path.cwd())
+            console.print(f"  • {rel_path}")
+        if len(files_affected) > 10:
+            console.print(f"  ... and {len(files_affected) - 10} more")
 
     console.print()
 
@@ -1157,8 +1162,15 @@ def recheck_rule_violations(rule_name: str, files_affected: List[Path], processo
             # Show affected files in the same format as process_single_rule
             files_with_issues = list(set(v.file_path for v in rule_issues))
             console.print("These files have this issue:")
-            for file_path in files_with_issues:
-                console.print(f"  • {file_path}")
+            # Use the processor's file list display helper if available
+            if hasattr(processor, '_display_file_list'):
+                processor._display_file_list(files_with_issues, rule_name, show_all=False, max_display=10)
+            else:
+                # Fallback to inline display
+                for file_path in files_with_issues[:10]:
+                    console.print(f"  • {file_path}")
+                if len(files_with_issues) > 10:
+                    console.print(f"  ... and {len(files_with_issues) - 10} more")
                 
     except Exception as e:
         console.print(f"[red]Error during recheck: {e}[/red]")


### PR DESCRIPTION
  Features Added:

  1. --show-all flag: Displays all affected files without truncation (defaults to showing 10 files then "... and X more")
  2. --export-files option: Exports the complete list of affected files to a specified file, organized by rule

  Implementation Details:

  - Added options to both the CLI interface and check command
  - Created _display_file_list() helper method in processor for consistent file list display
  - Updated display_summary() to support new options
  - Export format includes metadata (timestamp, total files, total issues) and groups files by rule name
  - Journey command now uses the same file display helper for consistency

  Testing Verified:

  - Normal truncated output (default behavior preserved)
  - --show-all displays all files inline
  - --export-files creates a well-formatted text file
  - Both options work together
  - Export file is sorted and organized by rule name

  The implementation provides users flexibility to see complete file lists when needed, while maintaining clean terminal output by default.